### PR TITLE
Fix for loading spinners

### DIFF
--- a/kindeSrc/environment/pages/(kinde)/(default)/page.tsx
+++ b/kindeSrc/environment/pages/(kinde)/(default)/page.tsx
@@ -160,7 +160,7 @@ function Layout({ request }) {
         <header className="header">
           <div className="logo">Chillspace</div>
         </header>
-        <main className="main">
+        <main className="main" data-roast-root="true">
           <div className="container">{getKindeWidget()}</div>
         </main>
         <footer className="footer">

--- a/kindeSrc/environment/pages/(kinde)/(index)/page.tsx
+++ b/kindeSrc/environment/pages/(kinde)/(index)/page.tsx
@@ -158,7 +158,7 @@ function Layout({ request }) {
         <header className="header">
           <div className="logo">Chillspace (index page)</div>
         </header>
-        <main className="main">
+        <main className="main" data-roast-root="true">
           <div className="container">{getKindeWidget()}</div>
         </main>
         <footer className="footer">


### PR DESCRIPTION
Hey @tamalchowdhury can you see if this fixes the pages where you were getting the infinite spinners.

I've added `data-roast-root="true"` to the `<main` element which allows Kinde's SPA like behaviour to switch out pages. 

I don't think we mention in the doc that this is essentially the entry point for anything that needs to be re-rendered.

I'll have a think on how we can handle this better